### PR TITLE
fix: add prefix 'test.' to test executable names

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ macro(add_libdomain_test test_executable sources)
   add_custom_command(TARGET ${test_executable} POST_BUILD COMMAND
       ${CMAKE_COMMAND} ARGS -E copy
         $<TARGET_FILE:${test_executable}>
-        ${CMAKE_BINARY_DIR}/bin/$<TARGET_FILE_NAME:${test_executable}>
+        "${CMAKE_BINARY_DIR}/bin/${test_name_local}"
       COMMENT "Copy ${test_executable} to ${CMAKE_BINARY_DIR}/bin")
 endmacro(add_libdomain_test)
 


### PR DESCRIPTION
## Description

Add prefix 'test.' to test executable names.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style adopted in this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
