### PR TITLE
fix: prevent unbind on error state

### DIFF
--- a/.gear/libdomain.spec
+++ b/.gear/libdomain.spec
@@ -1,7 +1,7 @@
 %define _unpackaged_files_terminate_build 1
 
 Name: libdomain
-Version: 0.7.0
+Version: 0.7.1
 Release: alt1
 
 Summary: Libdomain library provides ability to manipulate LDAP entries.
@@ -70,6 +70,10 @@ install -v -p -m 644 -D %_builddir/%name-%version/src/*.h %buildroot%_includedir
 %_bindir/*
 
 %changelog
+* Thu Aug 24 2023 Vladimir Rubanov <august@altlinux.org> 0.7.1-alt1
+- Fixes:
+  + Fixes unbind in error state.
+
 * Thu Jun 14 2023 Vladimir Rubanov <august@altlinux.org> 0.7.0-alt1
 - Implemented:
   + Implement test stubs for TLS, timeout testing.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ "alt:sisyphus", "alt:p10" ]
+        os: [ "alt:p10" ]
         architecture: [ amd64, i386 ]
       fail-fast: false
     uses: ./.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ "alt:sisyphus", "alt:p10" ]
+        os: [ "alt:p10" ]
         architecture: [ amd64, i386 ]
       fail-fast: false
     uses: ./.github/workflows/test.yml

--- a/src/connection.c
+++ b/src/connection.c
@@ -422,7 +422,10 @@ enum OperationReturnCode connection_close(struct ldap_connection_ctx_t *connecti
     }
 
     verto_free(connection->base);
-    ldap_unbind_ext(connection->ldap, NULL, NULL);
+    if (connection->state_machine->state != LDAP_CONNECTION_STATE_ERROR)
+    {
+        ldap_unbind_ext(connection->ldap, NULL, NULL);
+    }
     return RETURN_CODE_SUCCESS;
 }
 


### PR DESCRIPTION
## Description
Prevent libldap from unbind when ldap handle in error state.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style adopted in this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
