### PR TITLE
fix: repeat bind operation if connection is still in progress

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -29,6 +29,7 @@ enum OperationReturnCode
     RETURN_CODE_FAILURE               = 2,
     RETURN_CODE_MISSING_ATTRIBUTE     = 3,
     RETURN_CODE_OPERATION_IN_PROGRESS = 4,
+    RETURN_CODE_REPEAT_LAST_OPERATION = 5,
 };
 
 typedef struct ldap_global_context_t

--- a/src/connection.c
+++ b/src/connection.c
@@ -371,6 +371,14 @@ enum OperationReturnCode connection_sasl_bind(struct ldap_connection_ctx_t *conn
                             connection->ldap_params->serverctrls,
                             connection->ldap_params->clientctrls,
                             &msgid);
+
+    if (rc == LDAP_X_CONNECTING)
+    {
+        info("Continuing connection to LDAP server.\n");
+
+        return RETURN_CODE_REPEAT_LAST_OPERATION;
+    }
+
     if (rc != LDAP_SUCCESS)
     {
         // TODO: Verify that we need to perform abandon operation here.
@@ -490,6 +498,13 @@ enum OperationReturnCode connection_ldap_bind(struct ldap_connection_ctx_t *conn
                                     &connection->rmech,
                                     &msgid);
     ldap_msgfree(bind_message);
+
+    if (rc == LDAP_X_CONNECTING)
+    {
+        info("Continuing connection to LDAP server.\n");
+
+        return RETURN_CODE_REPEAT_LAST_OPERATION;
+    }
 
     if (rc != LDAP_SUCCESS && rc != LDAP_SASL_BIND_IN_PROGRESS)
     {


### PR DESCRIPTION
## Description

ldap_<type>_bind operations can return LDAP_X_CONNECTING in async mode. This patch allows library to
correctly handle this situation.

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code follows the code style adopted in this project
- [ ] My changes generate no new warnings
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
