### PR TITLE
fix: adjust container configuration to repair ci

### DIFF
--- a/src/domain.c
+++ b/src/domain.c
@@ -309,7 +309,7 @@ void ld_init(LDHandle** handle, const ld_config_t* config)
         (*handle)->config_ctx->sasl_options->passwd = talloc_strdup((*handle)->global_ctx->talloc_ctx, config->password);
 
         (*handle)->config_ctx->sasl_options->sasl_nocanon = true;
-        (*handle)->config_ctx->sasl_options->sasl_secprops = "maxssf=56";
+        (*handle)->config_ctx->sasl_options->sasl_secprops = "minssf=56,maxssf=56";
         (*handle)->config_ctx->sasl_options->sasl_flags = LDAP_SASL_QUIET;
 
     }

--- a/src/domain.c
+++ b/src/domain.c
@@ -309,7 +309,7 @@ void ld_init(LDHandle** handle, const ld_config_t* config)
         (*handle)->config_ctx->sasl_options->passwd = talloc_strdup((*handle)->global_ctx->talloc_ctx, config->password);
 
         (*handle)->config_ctx->sasl_options->sasl_nocanon = true;
-        (*handle)->config_ctx->sasl_options->sasl_secprops = "minssf=56,maxssf=56";
+        (*handle)->config_ctx->sasl_options->sasl_secprops = "minssf=56";
         (*handle)->config_ctx->sasl_options->sasl_flags = LDAP_SASL_QUIET;
 
     }

--- a/tests/auto/bind/bind.c
+++ b/tests/auto/bind/bind.c
@@ -60,7 +60,7 @@ Ensure(Cgreen, connection_sasl_bind_test) {
     ctx->config.sasl_options->passwd = NULL;
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
     ctx->connection_ctx.ldap_params = talloc(ctx->global_ctx.talloc_ctx, struct ldap_sasl_params_t);
     ctx->connection_ctx.ldap_params->dn = NULL;

--- a/tests/auto/bind/bind.c
+++ b/tests/auto/bind/bind.c
@@ -60,7 +60,7 @@ Ensure(Cgreen, connection_sasl_bind_test) {
     ctx->config.sasl_options->passwd = NULL;
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
     ctx->connection_ctx.ldap_params = talloc(ctx->global_ctx.talloc_ctx, struct ldap_sasl_params_t);
     ctx->connection_ctx.ldap_params->dn = NULL;

--- a/tests/auto/configure/configure.c
+++ b/tests/auto/configure/configure.c
@@ -76,7 +76,7 @@ Ensure(Cgreen, connection_configure_with_sasl_test) {
     ctx->config.sasl_options->passwd = NULL;
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
 
     enum OperationReturnCode rc = connection_configure(&ctx->global_ctx, &ctx->connection_ctx, &ctx->config);

--- a/tests/auto/configure/configure.c
+++ b/tests/auto/configure/configure.c
@@ -76,7 +76,7 @@ Ensure(Cgreen, connection_configure_with_sasl_test) {
     ctx->config.sasl_options->passwd = NULL;
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
 
     enum OperationReturnCode rc = connection_configure(&ctx->global_ctx, &ctx->connection_ctx, &ctx->config);

--- a/tests/auto/connection_state_machine/connection_state_machine.c
+++ b/tests/auto/connection_state_machine/connection_state_machine.c
@@ -87,7 +87,7 @@ Ensure(Cgreen, connection_state_machine_next_state) {
     ctx->config.sasl_options->passwd = "password";
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
     ctx->connection_ctx.ldap_params = talloc(ctx->global_ctx.talloc_ctx, struct ldap_sasl_params_t);
     ctx->connection_ctx.ldap_params->dn = "cn=admin,dc=domain,dc=alt";

--- a/tests/auto/connection_state_machine/connection_state_machine.c
+++ b/tests/auto/connection_state_machine/connection_state_machine.c
@@ -87,7 +87,7 @@ Ensure(Cgreen, connection_state_machine_next_state) {
     ctx->config.sasl_options->passwd = "password";
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
     ctx->connection_ctx.ldap_params = talloc(ctx->global_ctx.talloc_ctx, struct ldap_sasl_params_t);
     ctx->connection_ctx.ldap_params->dn = "cn=admin,dc=domain,dc=alt";

--- a/tests/auto/directory/directory.c
+++ b/tests/auto/directory/directory.c
@@ -111,7 +111,7 @@ Ensure(Cgreen, get_diretory_type_test) {
     ctx->config.sasl_options->passwd = NULL;
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
     ctx->connection_ctx.ldap_params = talloc(ctx->global_ctx.talloc_ctx, struct ldap_sasl_params_t);
     ctx->connection_ctx.ldap_params->dn = NULL;

--- a/tests/auto/directory/directory.c
+++ b/tests/auto/directory/directory.c
@@ -111,7 +111,7 @@ Ensure(Cgreen, get_diretory_type_test) {
     ctx->config.sasl_options->passwd = NULL;
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
     ctx->connection_ctx.ldap_params = talloc(ctx->global_ctx.talloc_ctx, struct ldap_sasl_params_t);
     ctx->connection_ctx.ldap_params->dn = NULL;

--- a/tests/auto/timeout/timeout.c
+++ b/tests/auto/timeout/timeout.c
@@ -63,7 +63,7 @@ Ensure(Cgreen, connection_set_timeout_test) {
     ctx->config.sasl_options->passwd = NULL;
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
 
     ctx->config.network_timeout = 1000;

--- a/tests/auto/timeout/timeout.c
+++ b/tests/auto/timeout/timeout.c
@@ -63,7 +63,7 @@ Ensure(Cgreen, connection_set_timeout_test) {
     ctx->config.sasl_options->passwd = NULL;
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
 
     ctx->config.network_timeout = 1000;

--- a/tests/auto/tls/tls.c
+++ b/tests/auto/tls/tls.c
@@ -157,7 +157,7 @@ Ensure(Cgreen, tls_connection_test) {
     ctx->config.sasl_options->passwd = "";
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
     ctx->connection_ctx.ldap_params = talloc(ctx->global_ctx.talloc_ctx, struct ldap_sasl_params_t);
     ctx->connection_ctx.ldap_params->dn = NULL;

--- a/tests/auto/tls/tls.c
+++ b/tests/auto/tls/tls.c
@@ -157,7 +157,7 @@ Ensure(Cgreen, tls_connection_test) {
     ctx->config.sasl_options->passwd = "";
 
     ctx->config.sasl_options->sasl_nocanon = true;
-    ctx->config.sasl_options->sasl_secprops = "minssf=56,maxssf=56";
+    ctx->config.sasl_options->sasl_secprops = "minssf=56";
     ctx->config.sasl_options->sasl_flags = LDAP_SASL_QUIET;
     ctx->connection_ctx.ldap_params = talloc(ctx->global_ctx.talloc_ctx, struct ldap_sasl_params_t);
     ctx->connection_ctx.ldap_params->dn = NULL;

--- a/tests/samba-container/krb5.conf
+++ b/tests/samba-container/krb5.conf
@@ -15,6 +15,8 @@
 [realms]
 DOMAIN.ALT = {
   default_domain = domain.alt
+  admin_server = dc0.domain.alt
+  kdc = dc0.domain.alt
 }
 
 [domain_realm]

--- a/tests/samba-container/provision-samba.sh
+++ b/tests/samba-container/provision-samba.sh
@@ -24,12 +24,6 @@ samba-tool domain provision\
 
 control bind-chroot disabled
 
-grep -q KRB5RCACHETYPE /etc/sysconfig/bind || echo 'KRB5RCACHETYPE="none"' >> /etc/sysconfig/bind
-
-grep -q 'bind-dns' /etc/bind/named.conf || echo 'include "/var/lib/samba/bind-dns/named.conf";' >> /etc/bind/named.conf
-
-mv /options.conf /etc/bind/options.conf
-
 mv /krb5.conf /etc/krb5.conf
 
 cat /resolv.conf > /etc/resolv.conf

--- a/tests/samba-container/provision-samba.sh
+++ b/tests/samba-container/provision-samba.sh
@@ -16,7 +16,7 @@ rm /etc/samba/smb.conf
 samba-tool domain provision\
  --server-role=dc\
  --use-rfc2307\
- --dns-backend=BIND9_DLZ\
+ --dns-backend=SAMBA_INTERNAL\
  --realm=DOMAIN.ALT\
  --domain=DOMAIN\
  --adminpass=password145Qw!\

--- a/tests/samba-container/start-samba.sh
+++ b/tests/samba-container/start-samba.sh
@@ -2,8 +2,6 @@
 
 mkdir /tmp/samba
 
-/usr/sbin/named -g -c /etc/bind/named.conf -d 10  -L /var/log/named.log -t / &
-
 samba --foreground  --no-process-group --debug-stdout &
 
 if [ $? -ne 0 ]; then

--- a/tests/testenv-container/krb5.conf
+++ b/tests/testenv-container/krb5.conf
@@ -15,6 +15,8 @@
 [realms]
 DOMAIN.ALT = {
   default_domain = domain.alt
+  admin_server = dc0.domain.alt
+  kdc = dc0.domain.alt
 }
 
 [domain_realm]

--- a/tests/testenv-container/make-test.sh
+++ b/tests/testenv-container/make-test.sh
@@ -8,4 +8,4 @@ cp /krb5.conf /etc/krb5.conf
 cat /resolv.conf > /etc/resolv.conf
 chown -R builder2:builder2 /app/
 echo 'password145Qw!' | kinit administrator@DOMAIN.ALT || :
-cd /app/ && rm -rf $BUILD_DIR && mkdir $BUILD_DIR && cd $BUILD_DIR && pwd && cmake -DLIBDOMAIN_BUILD_TESTS:BOOL=ON -B . .. && make && ctest --output-on-failure
+cd /app/ && rm -rf $BUILD_DIR && mkdir $BUILD_DIR && cd $BUILD_DIR && pwd && cmake -DLIBDOMAIN_BUILD_TESTS:BOOL=ON -B . .. && make && ctest --verbose


### PR DESCRIPTION
## Description

Sets minimum ssf level in secprops for sasl. And changes samba DNS backend to internal.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style adopted in this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
