### PR TITLE
fix: allocation check in `domain_p.h` and `computer.c`

### DIFF
--- a/src/computer.c
+++ b/src/computer.c
@@ -23,6 +23,7 @@
 #include "common.h"
 #include "domain_p.h"
 #include "entry.h"
+#include "helper_p.h"
 
 enum ComputerAttributeIndex
 {
@@ -81,13 +82,18 @@ enum OperationReturnCode ld_add_computer(LDHandle *handle,
  */
 enum OperationReturnCode ld_del_computer(LDHandle *handle, const char *name, const char *parent)
 {
-    TALLOC_CTX *talloc_ctx = talloc_new(NULL);
+    TALLOC_CTX *talloc_ctx;
+    ld_talloc_new(talloc_ctx, error_case, NULL);
 
     int rc = ld_del_entry(handle, name, parent ? parent : create_computer_parent(talloc_ctx, handle), "cn");
 
-    talloc_free(talloc_ctx);
+    ld_talloc_free(talloc_ctx, error_case);
 
     return rc;
+
+    // On any error.
+    error_case:
+    return RETURN_CODE_FAILURE;
 }
 
 /**
@@ -102,13 +108,18 @@ enum OperationReturnCode ld_del_computer(LDHandle *handle, const char *name, con
  */
 enum OperationReturnCode ld_mod_computer(LDHandle *handle, const char *name, const char *parent, LDAPAttribute_t **computer_attrs)
 {
-    TALLOC_CTX *talloc_ctx = talloc_new(NULL);
+    TALLOC_CTX *talloc_ctx;
+    ld_talloc_new(talloc_ctx, error_case, NULL);
 
     int rc = ld_mod_entry(handle, name, parent ? parent : create_computer_parent(talloc_ctx, handle), "cn", computer_attrs);
 
-    talloc_free(talloc_ctx);
+    ld_talloc_free(talloc_ctx, error_case);
 
     return rc;
+
+    // On any error
+    error_case:
+    return RETURN_CODE_FAILURE;
 }
 
 /**
@@ -123,11 +134,16 @@ enum OperationReturnCode ld_mod_computer(LDHandle *handle, const char *name, con
  */
 enum OperationReturnCode ld_rename_computer(LDHandle *handle, const char *old_name, const char *new_name, const char *parent)
 {
-    TALLOC_CTX *talloc_ctx = talloc_new(NULL);
+    TALLOC_CTX *talloc_ctx;
+    ld_talloc_new(talloc_ctx, error_case, NULL);
 
     int rc = ld_rename_entry(handle, old_name, new_name, parent ? parent : create_computer_parent(talloc_ctx, handle), "cn");
 
-    talloc_free(talloc_ctx);
+    ld_talloc_free(talloc_ctx, error_case);
 
     return rc;
+
+    // On any error
+    error_case:
+    return RETURN_CODE_FAILURE;
 }

--- a/src/computer.c
+++ b/src/computer.c
@@ -83,16 +83,16 @@ enum OperationReturnCode ld_add_computer(LDHandle *handle,
 enum OperationReturnCode ld_del_computer(LDHandle *handle, const char *name, const char *parent)
 {
     TALLOC_CTX *talloc_ctx;
-    ld_talloc_new(talloc_ctx, error_case, NULL);
+    ld_talloc_new(talloc_ctx, error_exit, NULL);
 
     int rc = ld_del_entry(handle, name, parent ? parent : create_computer_parent(talloc_ctx, handle), "cn");
 
-    ld_talloc_free(talloc_ctx, error_case);
+    ld_talloc_free(talloc_ctx, error_exit);
 
     return rc;
 
     // On any error.
-    error_case:
+    error_exit:
     return RETURN_CODE_FAILURE;
 }
 
@@ -109,16 +109,16 @@ enum OperationReturnCode ld_del_computer(LDHandle *handle, const char *name, con
 enum OperationReturnCode ld_mod_computer(LDHandle *handle, const char *name, const char *parent, LDAPAttribute_t **computer_attrs)
 {
     TALLOC_CTX *talloc_ctx;
-    ld_talloc_new(talloc_ctx, error_case, NULL);
+    ld_talloc_new(talloc_ctx, error_exit, NULL);
 
     int rc = ld_mod_entry(handle, name, parent ? parent : create_computer_parent(talloc_ctx, handle), "cn", computer_attrs);
 
-    ld_talloc_free(talloc_ctx, error_case);
+    ld_talloc_free(talloc_ctx, error_exit);
 
     return rc;
 
     // On any error
-    error_case:
+    error_exit:
     return RETURN_CODE_FAILURE;
 }
 
@@ -135,15 +135,15 @@ enum OperationReturnCode ld_mod_computer(LDHandle *handle, const char *name, con
 enum OperationReturnCode ld_rename_computer(LDHandle *handle, const char *old_name, const char *new_name, const char *parent)
 {
     TALLOC_CTX *talloc_ctx;
-    ld_talloc_new(talloc_ctx, error_case, NULL);
+    ld_talloc_new(talloc_ctx, error_exit, NULL);
 
     int rc = ld_rename_entry(handle, old_name, new_name, parent ? parent : create_computer_parent(talloc_ctx, handle), "cn");
 
-    ld_talloc_free(talloc_ctx, error_case);
+    ld_talloc_free(talloc_ctx, error_exit);
 
     return rc;
 
     // On any error
-    error_case:
+    error_exit:
     return RETURN_CODE_FAILURE;
 }

--- a/src/computer.c
+++ b/src/computer.c
@@ -82,7 +82,7 @@ enum OperationReturnCode ld_add_computer(LDHandle *handle,
  */
 enum OperationReturnCode ld_del_computer(LDHandle *handle, const char *name, const char *parent)
 {
-    TALLOC_CTX *talloc_ctx;
+    TALLOC_CTX *talloc_ctx = NULL;
     ld_talloc_new(talloc_ctx, error_exit, NULL);
 
     int rc = ld_del_entry(handle, name, parent ? parent : create_computer_parent(talloc_ctx, handle), "cn");
@@ -108,7 +108,7 @@ enum OperationReturnCode ld_del_computer(LDHandle *handle, const char *name, con
  */
 enum OperationReturnCode ld_mod_computer(LDHandle *handle, const char *name, const char *parent, LDAPAttribute_t **computer_attrs)
 {
-    TALLOC_CTX *talloc_ctx;
+    TALLOC_CTX *talloc_ctx = NULL;
     ld_talloc_new(talloc_ctx, error_exit, NULL);
 
     int rc = ld_mod_entry(handle, name, parent ? parent : create_computer_parent(talloc_ctx, handle), "cn", computer_attrs);
@@ -134,7 +134,7 @@ enum OperationReturnCode ld_mod_computer(LDHandle *handle, const char *name, con
  */
 enum OperationReturnCode ld_rename_computer(LDHandle *handle, const char *old_name, const char *new_name, const char *parent)
 {
-    TALLOC_CTX *talloc_ctx;
+    TALLOC_CTX *talloc_ctx = NULL;
     ld_talloc_new(talloc_ctx, error_exit, NULL);
 
     int rc = ld_rename_entry(handle, old_name, new_name, parent ? parent : create_computer_parent(talloc_ctx, handle), "cn");

--- a/src/domain_p.h
+++ b/src/domain_p.h
@@ -22,7 +22,7 @@
 #define LIB_DOMAIN_PRIVATE_H
 
 #include <stdbool.h>
-#include <talloc.h>
+#include "helper_p.h"
 
 typedef struct ld_config_s
 {
@@ -72,11 +72,11 @@ typedef struct ldhandle
         output = input; \
     }
 
-#define check_and_assign_attribute(attrs, value, index, talloc_ctx) \
+#define check_and_assign_attribute(error_handler, attrs, value, index, talloc_ctx) \
     if (value && strlen(value) > 0) \
     { \
-        attrs[index]->values    = talloc_array(talloc_ctx, char *, 2); \
-        attrs[index]->values[0] = talloc_strndup(talloc_ctx, value, strlen(value)); \
+        ld_talloc_array(attrs[index]->values, error_handler, talloc_ctx, char *, 2); \
+        ld_talloc_strndup(attrs[index]->values[0], error_handler, talloc_ctx, value, strlen(value)); \
         attrs[index]->values[1] = NULL; \
     }
 

--- a/src/helper_p.h
+++ b/src/helper_p.h
@@ -31,68 +31,68 @@
         ld_error(error); \
         goto error_handler; \
     }
-#define LD_FREE_HELPER(func, error, error_handler, var, ...) \
-    if (func(var, __VA_ARGS__) != 0) \
+#define LD_FREE_HELPER(func, error, error_handler, ctx, ...) \
+    if (func(ctx) != 0) \
     { \
-        var = NULL; \
+        ctx = NULL; \
         ld_error(error); \
         goto error_handler; \
     } \
-    var = NULL; 
+    ctx = NULL; 
 
-#define ld_alloc(var, error_handler, ctx, type) \
+#define ld_talloc(var, error_handler, ctx, type) \
     LD_ALLOC_HELPER(var, talloc, "Error - failed to allocate memory", error_handler, ctx, type)
 
-#define ld_alloc_array(var, error_handler, ctx, type, count) \
+#define ld_talloc_array(var, error_handler, ctx, type, count) \
     LD_ALLOC_HELPER(var, talloc_array, "Error - failed to allocate memory", error_handler, ctx, type, count)
 
-#define ld_alloc_size(var, error_handler, ctx, size) \
+#define ld_talloc_size(var, error_handler, ctx, size) \
     LD_ALLOC_HELPER(var, talloc_size, "Error - failed to allocate memory", error_handler, ctx, size)
 
-#define ld_alloc_zero(var, error_handler, ctx, type) \
+#define ld_talloc_zero(var, error_handler, ctx, type) \
     LD_ALLOC_HELPER(var, talloc_zero, "Error - failed to allocate memory", error_handler, ctx, type)
 
-#define ld_alloc_zero_array(var, error_handler, ctx, type, count) \
+#define ld_talloc_zero_array(var, error_handler, ctx, type, count) \
     LD_ALLOC_HELPER(var, talloc_zero_array, "Error - failed to allocate memory", error_handler, ctx, type, count)
 
-#define ld_alloc_zero_size(var, error_handler, ctx, size) \
+#define ld_talloc_zero_size(var, error_handler, ctx, size) \
     LD_ALLOC_HELPER(var, talloc_zero_size, "Error - failed to allocate memory", error_handler, ctx, size)
 
-#define ld_alloc_asprintf(var, error_handler, ctx, fmt, ...) \
+#define ld_talloc_asprintf(var, error_handler, ctx, fmt, ...) \
     LD_ALLOC_HELPER(var, talloc_asprintf, "Error - failed to allocate memory", error_handler, ctx, fmt, __VA_ARGS__)
 
-#define ld_alloc_asprintf_addbuf(var, error_handler, ps, fmt, ...) \
+#define ld_talloc_asprintf_addbuf(var, error_handler, ps, fmt, ...) \
     LD_ALLOC_HELPER(var, talloc_asprintf_addbuf, "Error - failed to allocate memory", error_handler, ps, fmt, __VA_ARGS__)
 
-#define ld_alloc_asprintf_append(var, error_handler, str, fmt, ...) \
+#define ld_talloc_asprintf_append(var, error_handler, str, fmt, ...) \
     LD_ALLOC_HELPER(var, talloc_asprintf_append, "Error - failed to allocate memory", error_handler, str, fmt, __VA_ARGS__)
 
-#define ld_alloc_asprintf_append_buffer(var, error_handler, str, fmt, ...) \
+#define ld_talloc_asprintf_append_buffer(var, error_handler, str, fmt, ...) \
     LD_ALLOC_HELPER(var, talloc_asprintf_append_buffer, "Error - failed to allocate memory", error_handler, str, fmt, __VA_ARGS__)
 
-#define ld_alloc_vasprintf(var, error_handler, ctx, fmt, valist) \
+#define ld_talloc_vasprintf(var, error_handler, ctx, fmt, valist) \
     LD_ALLOC_HELPER(var, talloc_vasprintf, "Error - failed to allocate memory", error_handler, ctx, fmt, valist)
 
-#define ld_alloc_vasprintf_append(var, error_handler, str, fmt, valist) \
+#define ld_talloc_vasprintf_append(var, error_handler, str, fmt, valist) \
     LD_ALLOC_HELPER(var, talloc_vasprintf_append, "Error - failed to allocate memory", str, fmt, valist)
 
-#define ld_alloc_vasprintf_append_buffer(var, error_handler, fmt, valist) \
+#define ld_talloc_vasprintf_append_buffer(var, error_handler, fmt, valist) \
     LD_ALLOC_HELPER(var, talloc_vasprintf_append_buffer, "Error - failed to allocate memory", error_handler, str, fmt, valist)
 
-#define ld_alloc_new(var, error_handler, ctx) \
+#define ld_talloc_new(var, error_handler, ctx) \
     LD_ALLOC_HELPER(var, talloc_new, "Error - failed to allocate memory", error_handler, ctx)
 
-#define ld_alloc_memdup(var, error_handler, t, p, size) \
+#define ld_talloc_memdup(var, error_handler, t, p, size) \
     LD_ALLOC_HELPER(var, talloc_memdup, "Error - failed to allocate memory", error_handler, t, p, size)
 
-#define ld_alloc_strdup(var, error_handler, ctx, str) \
+#define ld_talloc_strdup(var, error_handler, ctx, str) \
     LD_ALLOC_HELPER(var, talloc_strdup, "Error - failed to allocate memory", error_handler, ctx, str)
 
-#define ld_alloc_strndup(var, error_handler, ctx, str, n) \
+#define ld_talloc_strndup(var, error_handler, ctx, str, n) \
     LD_ALLOC_HELPER(var, talloc_strndup, "Error - failed to allocate memory", error_handler, ctx, str, n)
 
 
-#define ld_free(ctx, error_handler) \
+#define ld_talloc_free(ctx, error_handler) \
     LD_FREE_HELPER(talloc_free, "Error - failed to free memory", error_handler, ctx)
 
 

--- a/src/helper_p.h
+++ b/src/helper_p.h
@@ -1,0 +1,102 @@
+/***********************************************************************************************************************
+**
+** Copyright (C) 2023 BaseALT Ltd. <org@basealt.ru>
+**
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+**
+***********************************************************************************************************************/
+
+#ifndef LIB_DOMAIN_HELPER_PRIVATE_H
+#define LIB_DOMAIN_HELPER_PRIVATE_H
+
+#include <talloc.h>
+#include "common.h"
+
+#define LD_ALLOC_HELPER(var, func, error, error_handler, ...) \
+    var = func(__VA_ARGS__); \
+    if (var == NULL) \
+    { \
+        ld_error(error); \
+        goto error_handler; \
+    }
+#define LD_FREE_HELPER(func, error, error_handler, var, ...) \
+    if (func(var, __VA_ARGS__) != 0) \
+    { \
+        var = NULL; \
+        ld_error(error); \
+        goto error_handler; \
+    } \
+    var = NULL; 
+
+#define ld_alloc(var, error_handler, ctx, type) \
+    LD_ALLOC_HELPER(var, talloc, "Error - failed to allocate memory", error_handler, ctx, type)
+
+#define ld_alloc_array(var, error_handler, ctx, type, count) \
+    LD_ALLOC_HELPER(var, talloc_array, "Error - failed to allocate memory", error_handler, ctx, type, count)
+
+#define ld_alloc_size(var, error_handler, ctx, size) \
+    LD_ALLOC_HELPER(var, talloc_size, "Error - failed to allocate memory", error_handler, ctx, size)
+
+#define ld_alloc_zero(var, error_handler, ctx, type) \
+    LD_ALLOC_HELPER(var, talloc_zero, "Error - failed to allocate memory", error_handler, ctx, type)
+
+#define ld_alloc_zero_array(var, error_handler, ctx, type, count) \
+    LD_ALLOC_HELPER(var, talloc_zero_array, "Error - failed to allocate memory", error_handler, ctx, type, count)
+
+#define ld_alloc_zero_size(var, error_handler, ctx, size) \
+    LD_ALLOC_HELPER(var, talloc_zero_size, "Error - failed to allocate memory", error_handler, ctx, size)
+
+#define ld_alloc_asprintf(var, error_handler, ctx, fmt, ...) \
+    LD_ALLOC_HELPER(var, talloc_asprintf, "Error - failed to allocate memory", error_handler, ctx, fmt, __VA_ARGS__)
+
+#define ld_alloc_asprintf_addbuf(var, error_handler, ps, fmt, ...) \
+    LD_ALLOC_HELPER(var, talloc_asprintf_addbuf, "Error - failed to allocate memory", error_handler, ps, fmt, __VA_ARGS__)
+
+#define ld_alloc_asprintf_append(var, error_handler, str, fmt, ...) \
+    LD_ALLOC_HELPER(var, talloc_asprintf_append, "Error - failed to allocate memory", error_handler, str, fmt, __VA_ARGS__)
+
+#define ld_alloc_asprintf_append_buffer(var, error_handler, str, fmt, ...) \
+    LD_ALLOC_HELPER(var, talloc_asprintf_append_buffer, "Error - failed to allocate memory", error_handler, str, fmt, __VA_ARGS__)
+
+#define ld_alloc_vasprintf(var, error_handler, ctx, fmt, valist) \
+    LD_ALLOC_HELPER(var, talloc_vasprintf, "Error - failed to allocate memory", error_handler, ctx, fmt, valist)
+
+#define ld_alloc_vasprintf_append(var, error_handler, str, fmt, valist) \
+    LD_ALLOC_HELPER(var, talloc_vasprintf_append, "Error - failed to allocate memory", str, fmt, valist)
+
+#define ld_alloc_vasprintf_append_buffer(var, error_handler, fmt, valist) \
+    LD_ALLOC_HELPER(var, talloc_vasprintf_append_buffer, "Error - failed to allocate memory", error_handler, str, fmt, valist)
+
+#define ld_alloc_new(var, error_handler, ctx) \
+    LD_ALLOC_HELPER(var, talloc_new, "Error - failed to allocate memory", error_handler, ctx)
+
+#define ld_alloc_memdup(var, error_handler, t, p, size) \
+    LD_ALLOC_HELPER(var, talloc_memdup, "Error - failed to allocate memory", error_handler, t, p, size)
+
+#define ld_alloc_strdup(var, error_handler, ctx, str) \
+    LD_ALLOC_HELPER(var, talloc_strdup, "Error - failed to allocate memory", error_handler, ctx, str)
+
+#define ld_alloc_strndup(var, error_handler, ctx, str, n) \
+    LD_ALLOC_HELPER(var, talloc_strndup, "Error - failed to allocate memory", error_handler, ctx, str, n)
+
+
+#define ld_free(ctx, error_handler) \
+    LD_FREE_HELPER(talloc_free, "Error - failed to free memory", error_handler, ctx)
+
+
+
+
+
+#endif // LIB_DOMAIN_HELPER_PRIVATE_H


### PR DESCRIPTION
## Description
In libdomain, there are no memory allocation checks in many places. This PR should solve this.
- [x] Added `helper_p.h`
- [x] Replaced `talloc` on `ld_talloc` in `domain_p.h`
- [x] Replaced `talloc` on `ld_talloc` in `computer.c` 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style adopted in this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
