### PR TITLE
fix: replacing `talloc` with `ld_talloc` in `connection.c`

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -191,7 +191,6 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
 
     connection->rmech = NULL;
 
-    // steal on 314
     ld_talloc_e(connection->state_machine, error_exit, "Error - out of memory - unable to allocate memory for state_machine_ctx_t", talloc_ctx, struct state_machine_ctx_t);
 
     csm_init(connection->state_machine, connection);
@@ -225,7 +224,6 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
 
     set_ldap_option(connection->ldap, LDAP_OPT_CONNECT_ASYNC, LDAP_OPT_ON);
 
-    // steal on 315
     ld_talloc_zero_e(connection->ldap_defaults, error_exit, "Error - out of memory - unable to allocate memory for ldap_sasl_defaults_t", talloc_ctx, struct ldap_sasl_defaults_t);
 
     connection->ldap_defaults->mechanism = LDAP_SASL_SIMPLE;
@@ -243,7 +241,6 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
 
         if (config->sasl_options->mechanism)
         {
-            // steal on 318
             ld_talloc_strdup_e(connection->ldap_defaults->mechanism, error_exit, "Error - out of memory - unable to allocate memory for sasl mechanism", talloc_ctx, config->sasl_options->mechanism);
         }
     }

--- a/src/connection.c
+++ b/src/connection.c
@@ -198,7 +198,7 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
 
     if (config->search_timelimit > 0)
     {
-        search_timeout = connection_microseconds_to_timeval(talloc_ctx, config->search_timelimit);
+        search_timeout = connection_microseconds_to_timeval(global_ctx->talloc_ctx, config->search_timelimit);
 
         if (search_timeout == NULL)
         {
@@ -209,7 +209,7 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
         set_ldap_option(connection->ldap, LDAP_OPT_TIMELIMIT, search_timeout);
     }
 
-    network_timeout = connection_microseconds_to_timeval(talloc_ctx, config->network_timeout);
+    network_timeout = connection_microseconds_to_timeval(global_ctx->talloc_ctx, config->network_timeout);
 
     if (network_timeout == NULL)
     {

--- a/src/connection.c
+++ b/src/connection.c
@@ -130,7 +130,7 @@ static void search_requests_init(struct ldap_search_request_t* requests, int siz
 struct timeval* connection_microseconds_to_timeval(TALLOC_CTX *talloc_ctx, int microseconds)
 {
     struct timeval* time_interval = NULL;
-    ld_talloc(time_interval, error_exit, talloc_ctx, struct timeval);
+    ld_talloc_e(time_interval, error_exit, "Error - out of memory - unable to allocate memory for timeval", talloc_ctx, struct timeval);
 
     if (microseconds < 0)
     {
@@ -174,7 +174,7 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
     struct timeval* network_timeout = NULL;
 
     TALLOC_CTX* talloc_ctx = NULL;
-    ld_talloc_new(talloc_ctx, error_exit, NULL);
+    ld_talloc_new_e(talloc_ctx, error_exit, "Error - out of memory - unable to allocate memory for TALLOC_CTX\n", NULL);
 
     int rc = ldap_initialize(&connection->ldap, config->server);
 
@@ -192,8 +192,8 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
     connection->rmech = NULL;
 
     // steal on 311
-    ld_talloc(connection->state_machine, error_exit, talloc_ctx, struct state_machine_ctx_t);
-    
+    ld_talloc_e(connection->state_machine, error_exit, "Error - out of memory - unable to allocate memory for state_machine_ctx_t", talloc_ctx, struct state_machine_ctx_t);
+
     csm_init(connection->state_machine, connection);
 
     if (config->search_timelimit > 0)
@@ -202,7 +202,7 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
 
         if (search_timeout == NULL)
         {
-            ld_error("Error - failed to allocate memory");
+            ld_error("Error - out of memory - unable to allocate memory for timeval\n");
             goto error_exit;
         }
 
@@ -213,7 +213,7 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
 
     if (network_timeout == NULL)
     {
-        ld_error("Error - failed to allocate memory");
+        ld_error("Error - out of memory - unable to allocate memory for timeval\n");
         goto error_exit;
     }
 
@@ -226,7 +226,7 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
     set_ldap_option(connection->ldap, LDAP_OPT_CONNECT_ASYNC, LDAP_OPT_ON);
 
     // steal on 312
-    ld_talloc_zero(connection->ldap_defaults, error_exit, talloc_ctx, struct ldap_sasl_defaults_t);
+    ld_talloc_zero_e(connection->ldap_defaults, error_exit, "Error - out of memory - unable to allocate memory for ldap_sasl_defaults_t", talloc_ctx, struct ldap_sasl_defaults_t);
 
     connection->ldap_defaults->mechanism = LDAP_SASL_SIMPLE;
 
@@ -242,7 +242,7 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
         connection->ldap_defaults->flags = config->sasl_options->sasl_flags;
 
         // steal on 315
-        ld_talloc_strdup(connection->ldap_defaults->mechanism, error_exit, talloc_ctx, config->sasl_options->mechanism);
+        ld_talloc_strdup_e(connection->ldap_defaults->mechanism, error_exit, "Error - out of memory - unable to allocate memory for sasl mechanism", talloc_ctx, config->sasl_options->mechanism);
     }
 
     if (config->use_start_tls)

--- a/src/connection.c
+++ b/src/connection.c
@@ -191,7 +191,7 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
 
     connection->rmech = NULL;
 
-    // steal on 311
+    // steal on 314
     ld_talloc_e(connection->state_machine, error_exit, "Error - out of memory - unable to allocate memory for state_machine_ctx_t", talloc_ctx, struct state_machine_ctx_t);
 
     csm_init(connection->state_machine, connection);
@@ -225,7 +225,7 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
 
     set_ldap_option(connection->ldap, LDAP_OPT_CONNECT_ASYNC, LDAP_OPT_ON);
 
-    // steal on 312
+    // steal on 315
     ld_talloc_zero_e(connection->ldap_defaults, error_exit, "Error - out of memory - unable to allocate memory for ldap_sasl_defaults_t", talloc_ctx, struct ldap_sasl_defaults_t);
 
     connection->ldap_defaults->mechanism = LDAP_SASL_SIMPLE;
@@ -241,8 +241,11 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
 
         connection->ldap_defaults->flags = config->sasl_options->sasl_flags;
 
-        // steal on 315
-        ld_talloc_strdup_e(connection->ldap_defaults->mechanism, error_exit, "Error - out of memory - unable to allocate memory for sasl mechanism", talloc_ctx, config->sasl_options->mechanism);
+        if (config->sasl_options->mechanism)
+        {
+            // steal on 318
+            ld_talloc_strdup_e(connection->ldap_defaults->mechanism, error_exit, "Error - out of memory - unable to allocate memory for sasl mechanism", talloc_ctx, config->sasl_options->mechanism);
+        }
     }
 
     if (config->use_start_tls)

--- a/src/connection.c
+++ b/src/connection.c
@@ -322,7 +322,8 @@ enum OperationReturnCode connection_configure(struct ldap_global_context_t *glob
     error_exit:
         if (talloc_ctx)
         {
-            ld_talloc_free(talloc_ctx, error_exit);
+            talloc_free(talloc_ctx);
+            talloc_ctx = NULL;
         }
         return RETURN_CODE_FAILURE;
 }
@@ -722,7 +723,7 @@ enum OperationReturnCode connection_close(struct ldap_connection_ctx_t *connecti
     return RETURN_CODE_SUCCESS;
 
     error_exit:
-    return RETURN_CODE_FAILURE;
+        return RETURN_CODE_FAILURE;
 }
 
 /**
@@ -797,8 +798,6 @@ enum OperationReturnCode connection_bind_on_read(int rc, LDAPMessage * message, 
     return RETURN_CODE_SUCCESS;
 
     error_exit:
-        // TODO: consider what needs to be added in order to correctly return the error without breaking anything
-        // (or break minimally)
         return RETURN_CODE_FAILURE;
 }
 
@@ -853,7 +852,5 @@ enum OperationReturnCode connection_start_tls_on_read(int rc, LDAPMessage * mess
     return RETURN_CODE_SUCCESS;
 
     error_exit:
-        // TODO: consider what needs to be added in order to correctly return the error without breaking anything
-        // (or break minimally)
         return RETURN_CODE_FAILURE;
 }


### PR DESCRIPTION
## Description
In libdomain, there are no memory allocation checks in many places. This PR should solve some of this.
Continue of #80 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style adopted in this project
- [ ] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
