### PR TITLE
fix: replacing some `talloc` with `ld_talloc` in `entry.c`

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -326,9 +326,9 @@ enum OperationReturnCode search_on_read(int rc, LDAPMessage *message, struct lda
                             while (entry_index)
                             {
                                 --entry_index;
-                                ldap_memfree(entries[entry_index]);
+                                ld_talloc_free(entries[entry_index], error_exit);
                             }
-                            talloc_free(entries);
+                            ld_talloc_free(entries, error_exit);
                             entries = NULL;
                         }
                         goto error_exit;

--- a/src/entry.c
+++ b/src/entry.c
@@ -913,7 +913,7 @@ static void fill_attribute(gpointer key, gpointer value, gpointer userdata)
                 // ^0             ^1  ... ^value_index-2 ^value_index-1 ^value_index
                 --value_index; 
                 ld_talloc_free(attribute->values[value_index], error_exit);
-                // on ld_talloc_free error will be skiped.
+                // on ld_talloc_free error will be skipped.
             }
             ld_talloc_free(attribute->values, error_exit);
         }
@@ -967,7 +967,7 @@ LDAPAttribute_t **ld_entry_get_attributes(ld_entry_t *entry)
                 // ^0       ^1  ... ^index-2 ^index-1 ^index
                 --index; 
                 ld_talloc_free(result[index], error_exit);
-                // on ld_talloc_free error will be skiped.
+                // on ld_talloc_free error will be skipped.
             }
             ld_talloc_free(result, error_exit);
         }

--- a/src/entry.c
+++ b/src/entry.c
@@ -907,6 +907,8 @@ static void fill_attribute(gpointer key, gpointer value, gpointer userdata)
 
     attribute->values[index] = NULL;
 
+    return;
+
     error_exit:
         if (attribute->values)
         {

--- a/src/entry.c
+++ b/src/entry.c
@@ -311,7 +311,7 @@ enum OperationReturnCode search_on_read(int rc, LDAPMessage *message, struct lda
 
                     if (entry_index + 2 >= entries_size)
                     {
-                        ld_talloc_realloc(entries, error_exit, connection->handle->talloc_ctx, NULL, ld_entry_t*, entries_size * 2);
+                        ld_talloc_realloc(entries, error_exit, connection->handle->talloc_ctx, ld_entry_t*, entries_size * 2);
                     }
 
                     char* dn = ldap_get_dn(connection->ldap, message);
@@ -772,7 +772,7 @@ ld_entry_t* ld_entry_new(TALLOC_CTX *ctx, const char* dn)
     ld_talloc_zero(result, error_exit, ctx, ld_entry_t);
 
     result->dn = NULL;
-    ld_talloc_strdup(result, error_exit, result, dn);
+    ld_talloc_strdup(result->dn, error_exit, result, dn);
 
     result->attributes = g_hash_table_new(g_str_hash, g_str_equal);
 
@@ -971,5 +971,4 @@ LDAPAttribute_t **ld_entry_get_attributes(ld_entry_t *entry)
             }
             ld_talloc_free(result, error_exit);
         }
-        return;
 }


### PR DESCRIPTION
## Description
In libdomain, there are no memory allocation checks in many places. This PR should solve some of this.
Continue of #80, #81 and #82

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style adopted in this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
