### PR TITLE
style: replace `talloc` with `ld_talloc` in `request_queue.c`

### DIFF
--- a/src/request_queue.c
+++ b/src/request_queue.c
@@ -40,7 +40,7 @@ struct request_queue
 request_queue *request_queue_new(TALLOC_CTX *ctx, unsigned int capacity)
 {
     request_queue* result = NULL;
-    ld_talloc_zero(result, error_exit, ctx, struct request_queue);
+    ld_talloc_zero_e(result, error_exit, "Unable to allocate request_queue.\n", ctx, struct request_queue);
 
     result->capacity = capacity;
 

--- a/src/request_queue.c
+++ b/src/request_queue.c
@@ -19,6 +19,7 @@
 ***********************************************************************************************************************/
 
 #include "request_queue.h"
+#include "helper_p.h"
 
 struct request_queue
 {
@@ -38,17 +39,15 @@ struct request_queue
  */
 request_queue *request_queue_new(TALLOC_CTX *ctx, unsigned int capacity)
 {
-    request_queue* result = talloc_zero(ctx, struct request_queue);
-    if (!result)
-    {
-        ld_error("Unable to allocate request_queue.\n");
-
-        return NULL;
-    }
+    request_queue* result = NULL;
+    ld_talloc_zero(result, error_exit, ctx, struct request_queue);
 
     result->capacity = capacity;
 
     return result;
+
+    error_exit:
+        return NULL;
 }
 
 /*!


### PR DESCRIPTION
## Description
In libdomain, there are no memory allocation checks in many places. This PR should solve some of this.
This change is rather a change in the style of the code, in line with similar changes in memory refactoring
Continue of #80, #81, #82, #84 and #86

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style adopted in this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
