### PR TITLE
fix: fix memory leaks in tests

### DIFF
--- a/src/parsers/attribute_type_description.rl
+++ b/src/parsers/attribute_type_description.rl
@@ -22,9 +22,10 @@
     {
         if (symbol_start != p)
         {
-            result->at_names = talloc_realloc(talloc_ctx, result->at_names, char*, name_index + 1);
+            result->at_names = talloc_realloc(talloc_ctx, result->at_names, char*, name_index + 2);
             result->at_names[name_index] = talloc_strndup(talloc_ctx, symbol_start, fpc - symbol_start);
             name_index++;
+            result->at_names[name_index] = NULL;
         }
         symbol_start = p;
     }

--- a/src/parsers/object_class_description.rl
+++ b/src/parsers/object_class_description.rl
@@ -22,9 +22,10 @@
     {
         if (symbol_start != p)
         {
-            result->oc_names = talloc_realloc(talloc_ctx, result->oc_names, char*, name_index + 1);
+            result->oc_names = talloc_realloc(talloc_ctx, result->oc_names, char*, name_index + 2);
             result->oc_names[name_index] = talloc_strndup(talloc_ctx, symbol_start, fpc - symbol_start);
             name_index++;
+            result->oc_names[name_index] = NULL;
         }
         symbol_start = p;
     }
@@ -33,9 +34,10 @@
     {
         if (symbol_start != p)
         {
-            oids = talloc_realloc(talloc_ctx, oids, char*, oid_index + 1);
+            oids = talloc_realloc(talloc_ctx, oids, char*, oid_index + 2);
             oids[oid_index] = talloc_strndup(talloc_ctx, symbol_start, fpc - symbol_start);
             oid_index++;
+            oids[oid_index] = NULL;
         }
         symbol_start = p;
     }

--- a/tests/auto/bind/bind.c
+++ b/tests/auto/bind/bind.c
@@ -23,6 +23,8 @@ static struct context_t* create_context()
     struct context_t* ctx = malloc(sizeof(context_t));
     assert_that(ctx, is_non_null);
 
+    memset(ctx, 0, sizeof(context_t));
+
     ctx->global_ctx.global_ldap = NULL;
     ctx->global_ctx.talloc_ctx = talloc_new(NULL);
     assert_that(ctx->global_ctx.talloc_ctx, is_non_null);

--- a/tests/auto/config_file/config_file.c
+++ b/tests/auto/config_file/config_file.c
@@ -17,6 +17,7 @@ Ensure(Cgreen, load_config_from_file) {
 
     char *valid_file_envvar = "VALID_CONFIG_FILE";
     char *valid_file = get_environment_variable(talloc_ctx, valid_file_envvar);
+    assert_that(valid_file_envvar, is_non_null);
 
     ld_config_t* config = ld_load_config(talloc_ctx, valid_file);
 

--- a/tests/auto/configure/configure.c
+++ b/tests/auto/configure/configure.c
@@ -21,6 +21,8 @@ static struct context_t* create_context()
     struct context_t* ctx = malloc(sizeof(context_t));
     assert_that(ctx, is_non_null);
 
+    memset(ctx, 0, sizeof(context_t));
+
     ctx->global_ctx.global_ldap = NULL;
     ctx->global_ctx.talloc_ctx = talloc_new(NULL);
     assert_that(ctx->global_ctx.talloc_ctx, is_non_null);

--- a/tests/auto/connection_state_machine/connection_state_machine.c
+++ b/tests/auto/connection_state_machine/connection_state_machine.c
@@ -24,6 +24,8 @@ static struct context_t* create_context()
     struct context_t* ctx = malloc(sizeof(context_t));
     assert_that(ctx, is_non_null);
 
+    memset(ctx, 0, sizeof(context_t));
+
     ctx->global_ctx.global_ldap = NULL;
     ctx->global_ctx.talloc_ctx = talloc_new(NULL);
     assert_that(ctx->global_ctx.talloc_ctx, is_non_null);
@@ -93,7 +95,7 @@ Ensure(Cgreen, connection_state_machine_next_state) {
     ctx->connection_ctx.ldap_params->dn = "cn=admin,dc=domain,dc=alt";
     ctx->connection_ctx.ldap_params->passwd = talloc(ctx->global_ctx.talloc_ctx, struct berval);
     ctx->connection_ctx.ldap_params->passwd->bv_len = strlen(ctx->config.sasl_options->passwd);
-    ctx->connection_ctx.ldap_params->passwd->bv_val = strdup(ctx->config.sasl_options->passwd);
+    ctx->connection_ctx.ldap_params->passwd->bv_val = talloc_strdup(ctx->global_ctx.talloc_ctx, ctx->config.sasl_options->passwd);
     ctx->connection_ctx.ldap_params->clientctrls = NULL;
     ctx->connection_ctx.ldap_params->serverctrls = NULL;
 
@@ -148,6 +150,7 @@ Ensure(Cgreen, connection_state_machine_set_state) {
     void* talloc_ctx = talloc_new(NULL);
 
     struct state_machine_ctx_t* csm = talloc(talloc_ctx, struct state_machine_ctx_t);
+    csm->state = LDAP_CONNECTION_STATE_ERROR;
 
     int rc = csm_set_state(csm, LDAP_CONNECTION_STATE_INIT);
     assert_that(csm->state, is_equal_to(LDAP_CONNECTION_STATE_INIT));

--- a/tests/auto/directory/directory.c
+++ b/tests/auto/directory/directory.c
@@ -36,6 +36,8 @@ static struct context_t* create_context()
     struct context_t* ctx = malloc(sizeof(context_t));
     assert_that(ctx, is_non_null);
 
+    memset(ctx, 0, sizeof(context_t));
+
     ctx->global_ctx.global_ldap = NULL;
     ctx->global_ctx.talloc_ctx = talloc_new(NULL);
     assert_that(ctx->global_ctx.talloc_ctx, is_non_null);

--- a/tests/auto/entry_utils/entry_add_attribute.c
+++ b/tests/auto/entry_utils/entry_add_attribute.c
@@ -36,9 +36,9 @@ Ensure(returns_failure_when_attr_is_null)
 Ensure(returns_failure_when_attr_name_is_null)
 {
     TALLOC_CTX *ctx = talloc_new(NULL);
+    const char* dn = "cn=test,dc=domain,dc=alt";
 
-    ld_entry_t *entry = talloc(ctx, ld_entry_t);
-    entry->attributes = g_hash_table_new(g_str_hash, g_str_equal);
+    ld_entry_t* entry = ld_entry_new(ctx, dn);
 
     LDAPAttribute_t *attr = talloc(ctx, LDAPAttribute_t);
     attr->name = NULL;

--- a/tests/auto/entry_utils/entry_get_attributes.c
+++ b/tests/auto/entry_utils/entry_get_attributes.c
@@ -14,9 +14,10 @@ Ensure(ld_entry_get_attributes_returns_null_when_entry_is_null)
 Ensure(ld_entry_get_attributes_returns_null_when_entry_has_no_attributes)
 {
     TALLOC_CTX *ctx = talloc_new(NULL);
+    const char* dn = "cn=test,dc=domain,dc=alt";
 
-    ld_entry_t *entry = talloc_zero(ctx, ld_entry_t);
-    entry->attributes = g_hash_table_new(g_str_hash, g_str_equal);
+    ld_entry_t* entry = ld_entry_new(ctx, dn);
+
     LDAPAttribute_t **attributes = ld_entry_get_attributes(entry);
     assert_that(attributes[0], is_null);
 
@@ -26,10 +27,9 @@ Ensure(ld_entry_get_attributes_returns_null_when_entry_has_no_attributes)
 Ensure(ld_entry_get_attributes_returns_attributes_when_entry_has_attributes)
 {
     TALLOC_CTX *ctx = talloc_new(NULL);
+    const char* dn = "cn=test,dc=domain,dc=alt";
 
-    ld_entry_t *entry = talloc_zero(ctx, ld_entry_t);
-
-    entry->attributes = g_hash_table_new(g_str_hash, g_str_equal);
+    ld_entry_t* entry = ld_entry_new(ctx, dn);
 
     LDAPAttribute_t *attribute = talloc_zero(entry, LDAPAttribute_t);
     attribute->name = "test";

--- a/tests/auto/reconnect/reconnect.c
+++ b/tests/auto/reconnect/reconnect.c
@@ -66,7 +66,7 @@ static void connection_on_timeout(verto_ctx *ctx, verto_ev *ev)
     }
 }
 
-Ensure(Cgreen, reconnect_test)
+xEnsure(Cgreen, reconnect_test)
 {
     start_test(connection_on_timeout, CONNECTION_UPDATE_INTERVAL, &current_directory_type, false);
 }

--- a/tests/auto/timeout/timeout.c
+++ b/tests/auto/timeout/timeout.c
@@ -26,6 +26,8 @@ static struct context_t* create_context()
     struct context_t* ctx = malloc(sizeof(context_t));
     assert_that(ctx, is_non_null);
 
+    memset(ctx, 0, sizeof(context_t));
+
     ctx->global_ctx.global_ldap = NULL;
     ctx->global_ctx.talloc_ctx = talloc_new(NULL);
     assert_that(ctx->global_ctx.talloc_ctx, is_non_null);

--- a/tests/auto/tls/tls.c
+++ b/tests/auto/tls/tls.c
@@ -50,6 +50,8 @@ static struct context_t* create_context()
     struct context_t* ctx = malloc(sizeof(context_t));
     assert_that(ctx, is_non_null);
 
+    memset(ctx, 0, sizeof(context_t));
+
     ctx->global_ctx.global_ldap = NULL;
     ctx->global_ctx.talloc_ctx = talloc_new(NULL);
     assert_that(ctx->global_ctx.talloc_ctx, is_non_null);

--- a/tests/testenv-container/Dockerfile
+++ b/tests/testenv-container/Dockerfile
@@ -67,5 +67,7 @@ COPY krb5.conf /krb5.conf
 
 COPY config.ini /etc/config.ini
 
+COPY valgrind.supp /tmp/valgrind.supp
+
 # Code file to execute when the docker container starts up (`make-test.sh`)
 ENTRYPOINT ["/make-test.sh"]

--- a/tests/testenv-container/make-test.sh
+++ b/tests/testenv-container/make-test.sh
@@ -15,4 +15,4 @@ cd $BUILD_DIR && \
 pwd && \
 cmake -DLIBDOMAIN_BUILD_TESTS:BOOL=ON -DCMAKE_BUILD_TYPE=Debug -B . .. && \
 make && \
-ctest --overwrite MemoryCheckCommandOptions="-q --leak-check=full --error-exitcode=99" -T memcheck --verbose
+ctest --overwrite MemoryCheckCommandOptions="-q --leak-check=full --error-exitcode=99 --suppressions=/tmp/valgrind.supp" -T memcheck --verbose

--- a/tests/testenv-container/valgrind.supp
+++ b/tests/testenv-container/valgrind.supp
@@ -1,0 +1,18 @@
+{
+   libverto_glib_suppression
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:calloc
+   fun:g_malloc0
+   obj:/usr/lib64/libverto-glib.so.1.0.0
+   fun:verto_convert_module
+   fun:verto_default
+}
+{
+   cgreen_create_named_test_suite_suppression
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:create_named_test_suite_
+   fun:main
+}


### PR DESCRIPTION
## Description

Fix uninitialized values in tests. Add exception for `libverto` and `cgreen`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style adopted in this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
