### PR TITLE
fix: use python 3.12.11 instead of 3.7 for codespell in `spellcheck.yml`

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.12.11
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.12.11
 
       - name: Install dependencies
         run: python -m pip install codespell


### PR DESCRIPTION
## Description

The latest version of codespell now requires python version 3.8 or higher. This PR simply changes the python version to a newer one.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style adopted in this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass with my changes
