### PR TITLE
fix: fix typo in src/entry.c

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -57,7 +57,7 @@ enum OperationReturnCode add(struct ldap_connection_ctx_t* connection, const cha
 }
 
 /**
- * @brief add_on_write   This callback called on complition of ldap add operation.
+ * @brief add_on_write   This callback called on completion of ldap add operation.
  * @param[in] rc         Return code of ldap_result.
  * @param[in] message    Message received from ldap.
  * @param[in] connection Connection to work with.
@@ -251,7 +251,7 @@ void connection_remove_search_request(struct ldap_connection_ctx_t *connection, 
 }
 
 /**
- * @brief search_on_read This callback called upon complition of ldap search operation.
+ * @brief search_on_read This callback called upon completion of ldap search operation.
  * @param[in] rc         Return code of ldap_result.
  * @param[in] message    Message received from ldap.
  * @param[in] connection Connection to work with.
@@ -424,7 +424,7 @@ enum OperationReturnCode modify(struct ldap_connection_ctx_t* connection, const 
 }
 
 /**
- * @brief modify_on_read This callback called upon complition of ldap modify operation.
+ * @brief modify_on_read This callback called upon completion of ldap modify operation.
  * @param rc             Return code of ldap_result.
  * @param message        Message received from ldap.
  * @param connection     Connection to work with.


### PR DESCRIPTION
## Description

Fix typo in `src/entry.c`.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style adopted in this project
- [x] My changes generate no new warnings
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
